### PR TITLE
Prevent danmaku block  video's subtitles and more translations

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,10 @@
                 },
                 danmaku: {
                     id: '9E2E3368B56CDBB4',
-                    api: 'https://api.prprpr.me/dplayer/'
+                    api: 'https://api.prprpr.me/dplayer/',
+                    margin: {
+                        bottom:'15%'
+                    }
                 }
             });
         </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@
                     id: '9E2E3368B56CDBB4',
                     api: 'https://api.prprpr.me/dplayer/',
                     margin: {
-                        bottom:'15%'
+                        bottom: '15%'
                     }
                 }
             });

--- a/src/html.js
+++ b/src/html.js
@@ -13,7 +13,7 @@ const html = {
             ${option.logo ? `
             <div class="dplayer-logo"><img src="${option.logo}"></div>
             ` : ``}
-            <div class="dplayer-danmaku">
+            <div class="dplayer-danmaku" style="${option.danmaku ? html.danmakumargin(option.danmaku.margin) : ``}">
                 <div class="dplayer-danmaku-item dplayer-danmaku-item--demo"></div>
             </div>
             <div class="dplayer-bezel">
@@ -172,6 +172,16 @@ const html = {
         </div>
         ${html.contextmenuList(option.contextmenu)}
         <div class="dplayer-notice"></div>`;
+    },
+
+    danmakumargin: (margin) => {
+        let result = '';
+        if (margin) {
+            for (const key in margin) {
+                result += `${key}:${margin[key]};`;
+            }
+        }
+        return result;
     },
 
     contextmenuList: (contextmenu) => {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,37 +1,70 @@
-const tranZH = {
-    'Danmaku is loading': '弹幕加载中',
-    'Top': '顶部',
-    'Bottom': '底部',
-    'Rolling': '滚动',
-    'Input danmaku, hit Enter': '输入弹幕，回车发送',
-    'About author': '关于作者',
-    'DPlayer feedback': '播放器意见反馈',
-    'About DPlayer': '关于 DPlayer 播放器',
-    'Loop': '洗脑循环',
-    'Speed': '速度',
-    'Opacity for danmaku': '弹幕透明度',
-    'Normal': '正常',
-    'Please input danmaku content!': '要输入弹幕内容啊喂！',
-    'Set danmaku color': '设置弹幕颜色',
-    'Set danmaku type': '设置弹幕类型',
-    'Danmaku': '弹幕',
-    'This video fails to load': '视频加载失败',
-    'Switching to': '正在切换至',
-    'Switched to': '已经切换至',
-    'quality': '画质',
-    'FF to': '快进至',
-    'REW to': '快退至',
-    'Volume': '音量'
-};
+/*
+W3C def language codes is :
+    language-code = primary-code ( "-" subcode )
+        primary-code    ISO 639-1   ( the names of language with 2 code )
+        subcode         ISO 3166    ( the names of countries )
+
+NOTE: use lowercase to prevent case typo from user! 
+Use this as shown below..... */
 
 module.exports = function (lang) {
     this.lang = lang;
     this.tran = (text) => {
-        if (this.lang === 'en') {
+        if (this.lang === 'en-us') {
             return text;
         }
-        else if (this.lang === 'zh') {
-            return tranZH[text];
-        }
+        else if (
+            // add language-code list here
+            this.lang === 'zh-cn' ||
+            this.lang === 'zh-tw'
+        ) { return tranTxt[this.lang][text]; }
     };
+};
+
+// add translation text here
+const tranTxt = {
+    "zh-cn" : {
+        'Danmaku is loading': '弹幕加载中',
+        'Top': '顶部',
+        'Bottom': '底部',
+        'Rolling': '滚动',
+        'Input danmaku, hit Enter': '输入弹幕，回车发送',
+        'About author': '关于作者',
+        'DPlayer feedback': '播放器意见反馈',
+        'About DPlayer': '关于 DPlayer 播放器',
+        'Loop': '洗脑循环',
+        'Speed': '速度',
+        'Opacity for danmaku': '弹幕透明度',
+        'Normal': '正常',
+        'Please input danmaku content!': '要输入弹幕内容啊喂！',
+        'Set danmaku color': '设置弹幕颜色',
+        'Set danmaku type': '设置弹幕类型',
+        'Danmaku': '弹幕',
+        'This video fails to load': '视频加载失败',
+        'Switching to': '正在切换至',
+        'Switched to': '已经切换至',
+        'quality': '画质',
+    },
+    "zh-tw" : {
+        'Danmaku is loading': '彈幕加載中',
+        'Top': '頂部',
+        'Bottom': '底部',
+        'Rolling': '滾動',
+        'Input danmaku, hit Enter': '輸入彈幕，Enter 發送',
+        'About author': '關於作者',
+        'DPlayer feedback': '播放器意見反饋',
+        'About DPlayer': '關於 DPlayer 播放器',
+        'Loop': '循環播放',
+        'Speed': '速度',
+        'Opacity for danmaku': '彈幕透明度',
+        'Normal': '正常',
+        'Please input danmaku content!': '請輸入彈幕内容啊！',
+        'Set danmaku color': '設置彈幕顏色',
+        'Set danmaku type': '設置彈幕類型',
+        'Danmaku': '彈幕',
+        'This video fails to load': '視頻加載失敗',
+        'Switching to': '正在切換至',
+        'Switched to': '已經切換至',
+        'quality': '畫質',
+    }
 };

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -10,14 +10,12 @@ Use this as shown below..... */
 module.exports = function (lang) {
     this.lang = lang;
     this.tran = (text) => {
-        if (this.lang === 'en-us') {
+        if (tranTxt[this.lang]) {
+            return tranTxt[this.lang][text];
+        }
+        else {
             return text;
         }
-        else if (
-            // add language-code list here
-            this.lang === 'zh-cn' ||
-            this.lang === 'zh-tw'
-        ) { return tranTxt[this.lang][text]; }
     };
 };
 

--- a/src/option.js
+++ b/src/option.js
@@ -13,7 +13,7 @@ module.exports = (option) => {
         autoplay: false,
         theme: '#b7daff',
         loop: false,
-        lang: navigator.language.indexOf('zh') !== -1 ? 'zh' : 'en',
+        lang: (navigator.language || navigator.browserLanguage).toLowerCase().indexOf('zh-cn') !== -1 ? 'zh-cn' : 'en-us',
         screenshot: false,
         hotkey: true,
         preload: 'auto',
@@ -51,6 +51,10 @@ module.exports = (option) => {
 
     if (option.video.quality) {
         option.video.url = [option.video.quality[option.video.defaultQuality].url];
+    }
+
+    if (option.lang) {
+        option.lang.toLowerCase();
     }
 
     return option;

--- a/src/option.js
+++ b/src/option.js
@@ -13,7 +13,7 @@ module.exports = (option) => {
         autoplay: false,
         theme: '#b7daff',
         loop: false,
-        lang: (navigator.language || navigator.browserLanguage).toLowerCase().indexOf('zh-cn') !== -1 ? 'zh-cn' : 'en-us',
+        lang: (navigator.language || navigator.browserLanguage).toLowerCase(),
         screenshot: false,
         hotkey: true,
         preload: 'auto',


### PR DESCRIPTION
作者您好，最近採用 Dplayer 做為網站的撥放器，想避免擋到字幕和更多一點的翻譯，做了一些改變。
如果寫得不好，還請指教！非常感謝能有這麼棒的開源撥放器。

## src/options:
    - Browser langage support  IE6 ~ IE8,
    - Use lowercase to prevent case typo from user,
## src/i18n.js:
    - Replace "zh" and "us" with language-code to support more language trans,
    - add zh-tw translation.
## src/html.js:
    - Add option.danmaku.margin to prevent danmaku block  video's subtitles,
## demo/index.html:
    - Just demo danmaku.margin,