### PR TITLE
fix 'Hls is not supported 'in safari mobile

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -339,7 +339,7 @@ class DPlayer {
             // https://github.com/video-dev/hls.js
             case 'hls':
                 if (Hls) {
-                    if (Hls.isSupported()) {
+                    if (Hls.isSupported()||video.canPlayType('application/x-mpegURL') || video.canPlayType('application/vnd.apple.mpegURL')) {
                         const hls = new Hls();
                         hls.loadSource(video.src);
                         hls.attachMedia(video);


### PR DESCRIPTION
#221 

