### PR TITLE
fix volume button bug that cannot mute in Firefox

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -173,7 +173,7 @@ class Controller {
             document.addEventListener(utils.nameMap.dragEnd, volumeUp);
             this.player.template.volumeButton.classList.add('dplayer-volume-active');
         });
-        this.player.template.volumeIcon.addEventListener('click', () => {
+        this.player.template.volumeButtonIcon.addEventListener('click', () => {
             if (this.player.video.muted) {
                 this.player.video.muted = false;
                 this.player.switchVolumeIcon();

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -30,6 +30,7 @@ class Template {
         this.volumeBarWrap = this.container.querySelector('.dplayer-volume-bar');
         this.volumeBarWrapWrap = this.container.querySelector('.dplayer-volume-bar-wrap');
         this.volumeButton = this.container.querySelector('.dplayer-volume');
+        this.volumeButtonIcon = this.container.querySelector('.dplayer-volume-icon');
         this.volumeIcon = this.container.querySelector('.dplayer-volume-icon .dplayer-icon-content');
         this.playedBar = this.container.querySelector('.dplayer-played');
         this.loadedBar = this.container.querySelector('.dplayer-loaded');


### PR DESCRIPTION
`click` 事件绑定在了 `volumeIcon` 上，这在 Chrome 下是可以的，但在 Firefox 下会导致点击音量图标无法静音和取消静音。解决方法是绑定到他的 `parent ` 上。

另外静音了的图标建议换一个，比如画根斜杠什么的... 现在这个图标难以给用户一种“静音”的感觉。