### PR TITLE
Fix switch quality video loop bug.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -447,7 +447,7 @@ class DPlayer {
             }
             else {
                 this.seek(0);
-                video.play();
+                this.play();
             }
             if (this.danmaku) {
                 this.danmaku.danIndex = 0;


### PR DESCRIPTION
When video has ever switched quality, and looping is enabled, the deleted video object will receive the play event and starts to play in the background. The callback for play event should use player as reference instead of video, which is already deleted from DOM. 

There might be a garbege collection problem in the switch quality part, if the reference to the old video tag is kept somewhere in the event.