### PR TITLE
fix #359 and keep thumbnails within the player

### DIFF
--- a/src/css/controller.scss
+++ b/src/css/controller.scss
@@ -100,7 +100,6 @@
             position: absolute;
             left: 0px;
             top: -20px;
-            width: 30px;
             border-radius: 4px;
             padding: 5px 7px;
             background-color: rgba(0, 0, 0, 0.62);

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -134,7 +134,7 @@ class Controller {
                     this.thumbnails && this.thumbnails.show();
                 }
                 this.thumbnails && this.thumbnails.move(tx);
-                this.player.template.playedBarTime.style.left = `${(tx - 20)}px`;
+                this.player.template.playedBarTime.style.left = `${(tx - (time >= 3600 ? 25 : 20))}px`;
                 this.player.template.playedBarTime.innerText = utils.secondToTime(time);
                 this.player.template.playedBarTime.classList.remove('hidden');
             }

--- a/src/js/thumbnails.js
+++ b/src/js/thumbnails.js
@@ -19,7 +19,7 @@ class Thumbnails {
 
     move (position) {
         this.container.style.backgroundPosition = `-${(Math.ceil(position / this.barWidth * 100) - 1) * 160}px 0`;
-        this.container.style.left = `${(position - this.container.offsetWidth / 2)}px`;
+        this.container.style.left = `${Math.min(Math.max(position - this.container.offsetWidth / 2, -10), this.barWidth - 150)}px`;
     }
 
     hide () {


### PR DESCRIPTION
 - fix #359
 - 使视频缩略图保持在播放器内，不会溢出：

![default](https://user-images.githubusercontent.com/11173242/44534811-34703000-a72b-11e8-804d-31ded49e841d.png)
