### PR TITLE
 Fix scss build error and es5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ cache:
   yarn: true
   directories:
     - node_modules
+
+script:
+  yarn run build

--- a/src/css/controller.scss
+++ b/src/css/controller.scss
@@ -60,7 +60,7 @@
                 }
                 &~.dplayer-bar-preview {
                     opacity: 0;
-                },
+                }
                 &~.dplayer-bar-time {
                     opacity: 0;
                 }

--- a/src/js/contextmenu.js
+++ b/src/js/contextmenu.js
@@ -2,14 +2,13 @@ class ContextMenu {
     constructor (player) {
         this.player = player;
 
-        [...this.player.template.menuItem].map((item, index) => {
+        Array.prototype.slice.call(this.player.template.menuItem).forEach((item, index) => {
             if (this.player.options.contextmenu[index].click) {
                 item.addEventListener('click', () => {
                     this.player.options.contextmenu[index].click(this.player);
                     this.hide();
                 });
             }
-            return item;
         });
 
         this.player.container.addEventListener('contextmenu', (e) => {


### PR DESCRIPTION
And build project on Travis to test scss syntax.

---

`[...nodeList]` 语法使用 babel 翻译后会使用 es6 中的 `Array.from` 方法，这会导致一些不支持 es6 语法的浏览器报错，例如 Windows 微信电脑版中的浏览器...

详见 https://github.com/babel/babel/issues/934