### PR TITLE
First time quality switch to default quality should not fired.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -495,6 +495,7 @@ class DPlayer {
     }
 
     switchQuality (index) {
+        index = typeof index === 'string' ? parseInt(index) : index;
         if (this.qualityIndex === index || this.switchingQuality) {
             return;
         }


### PR DESCRIPTION
https://github.com/MoePlayer/DPlayer/blob/ca5404d829af2d155913b37afcbe71da4f6a5a51/src/js/player.js#L498

Default quality is passed in number type, while index is string, so `===` will return false on `0 === '0'` if default quality is 0, and user click the default quality option on UI for the first time.