### PR TITLE
fix safari, edge seek time error

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -48,7 +48,7 @@ const utils = {
     * getBoundingClientRect 在 Opera 10.5 及以下返回的值缺失 width、height 值
     */
     getBoundingClientRectViewLeft (element) {
-        const scrollTop = document.documentElement.scrollTop;
+        const scrollTop = window.scrollY || window.pageYOffset || document.body.scrollTop + (document.documentElement && document.documentElement.scrollTop || 0);
 
         if (element.getBoundingClientRect) {
             if (typeof this.getBoundingClientRectViewLeft.offset !== 'number') {


### PR DESCRIPTION
### 问题描述
在 safari, edge 浏览器下视频进度跳转不正常
### 问题原因
在上述浏览器中 scrollTop 值获取不正确
### 解决办法
参考 [https://stackoverflow.com/questions/20514596/document-documentelement-scrolltop-return-value-differs-in-chrome]("https://stackoverflow.com/questions/20514596/document-documentelement-scrolltop-return-value-differs-in-chrome")