### PR TITLE
去掉腾讯TBS内核下的视频推送。

### DIFF
--- a/src/template/video.art
+++ b/src/template/video.art
@@ -3,6 +3,7 @@
     class="dplayer-video {{ if current }}dplayer-video-current{{ /if }}"
     webkit-playsinline
     playsinline
+    x5-video-player-type="h5"
     {{ if pic }}poster="{{ pic }}"{{ /if }}
     {{ if screenshot || enableSubtitle }}crossorigin="anonymous"{{ /if }}
     {{ if preload }}preload="{{ preload }}"{{ /if }}


### PR DESCRIPTION
播放视频在腾讯内核下，会劫持播放并在播放结束后推送腾讯自己的广告。
x5-video-player-type="h5" 这个参数可以解决这个问题。
