### PR TITLE
docs: 在文档中增加使用谷歌 Shaka 播放 DASH 的说明。

### DIFF
--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -501,6 +501,35 @@ const dp = new DPlayer({
 });
 ```
 
+### MPEG DASH (Shaka)
+
+需要在 `DPlayer.min.js` 前面加载 [shaka-player.compiled.js](https://github.com/google/shaka-player)。
+
+```html
+<link rel="stylesheet" href="DPlayer.min.css">
+<div id="dplayer"></div>
+<script src="shaka-player.compiled.js"></script>
+<script src="DPlayer.min.js"></script>
+```
+
+```js
+const dp = new DPlayer({
+    container: document.getElementById('dplayer'),
+    screenshot: true,
+    video: {
+        url: 'demo.mpd',
+        type: 'shakaDash',
+        customType: {
+            'shakaDash': function (video, player) {
+                var src = video.src;
+                var playerShaka = new shaka.Player(video); // 将会修改 video.src
+                playerShaka.load(src);
+            }
+        }
+    }
+});
+```
+
 ### FLV
 
 需要在 `DPlayer.min.js` 前面加载 [flv.js](https://github.com/Bilibili/flv.js)。


### PR DESCRIPTION
虽然文档中已经介绍了如何播放 MPEG DASH 视频，但在我的测试中，dash.js 在切换清晰度时极易卡死，控制台显示反复请求同一个片段。此外，dash.js 在播放时经常卡顿，体验不佳。

谷歌的 [Shaka](https://github.com/google/shaka-player) 播放器也支持 DASH，并且效果比 dash.js 好得多，但是 `new shaka.Player(video)` 语句会修改 `video.src`，导致不能按照文档中那么写。为避免后人踩坑，提此 PR。