### PR TITLE
fix: progress bar NaN

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -9,6 +9,10 @@ const utils = {
     * @return {String} 00:00 or 00:00:00
     */
     secondToTime: (second) => {
+        second = second || 0;
+        if (second === 0 || second == Infinity || second.toString() === 'NaN') {
+          return '00:00'
+        }
         const add0 = (num) => num < 10 ? '0' + num : '' + num;
         const hour = Math.floor(second / 3600);
         const min = Math.floor((second - hour * 3600) / 60);


### PR DESCRIPTION
当时视频未开始播放时，拖动进度条，会导致播放时间为 ‘NaN:NaN:NaN’

When the video was not playing, dragging the progress bar resulted in a play time of'NaN: NaN: NaN: NaN'

![image](https://user-images.githubusercontent.com/28435056/63516497-8fe02400-c51f-11e9-9cbd-034c9a4ff117.png)
