### PR TITLE
Fix Chrome for Android 76 can't play Hls

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -333,8 +333,9 @@ class DPlayer {
                     this.type = 'normal';
                 }
             }
-
-            if (this.type === 'hls' && (video.canPlayType('application/x-mpegURL') || video.canPlayType('application/vnd.apple.mpegURL'))) {
+            const u = navigator.userAgent, app = navigator.appVersion;
+            const isIOS = !!u.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
+            if (this.type === 'hls' && isIOS && (video.canPlayType('application/x-mpegURL') !='probably' || video.canPlayType('application/vnd.apple.mpegURL') !='probably' )) {
                 this.type = 'normal';
             }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -333,8 +333,8 @@ class DPlayer {
                     this.type = 'normal';
                 }
             }
-            const u = navigator.userAgent, app = navigator.appVersion;
-            const isIOS = !!u.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
+            
+            const isIOS = !!navigator.userAgent.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
             if (this.type === 'hls' && isIOS && (video.canPlayType('application/x-mpegURL') !='' || video.canPlayType('application/vnd.apple.mpegURL') !='' )) {
                 this.type = 'normal';
             }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -335,7 +335,7 @@ class DPlayer {
             }
             const u = navigator.userAgent, app = navigator.appVersion;
             const isIOS = !!u.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
-            if (this.type === 'hls' && isIOS && (video.canPlayType('application/x-mpegURL') !='probably' || video.canPlayType('application/vnd.apple.mpegURL') !='probably' )) {
+            if (this.type === 'hls' && isIOS && (video.canPlayType('application/x-mpegURL') !='' || video.canPlayType('application/vnd.apple.mpegURL') !='' )) {
                 this.type = 'normal';
             }
 


### PR DESCRIPTION
### issuse
https://github.com/MoePlayer/DPlayer/issues/221

### hls.js
https://github.com/dailymotion/hls.js#compatibility
```
 iOS Safari "Mobile" does not support the MediaSource API. 
```