### PR TITLE
fix: Avoid Cannot read property 'left' of undefined

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -3,7 +3,7 @@ import utils from './utils';
 class FullScreen {
     constructor (player) {
         this.player = player;
-
+        this.lastScrollPosition = {left: 0, top: 0};
         this.player.events.on('webfullscreen', () => {
             this.player.resize();
         });


### PR DESCRIPTION
Error @ utils.setScrollPosition

Test on Chrome F12
```
function setScrollPosition ({left = 0, top = 0}) { console.log(left, top)};

setScrollPosition(undefined)
```
This will have TypeError (Avoid Cannot read property 'left' of undefined)

