### PR TITLE
Hide WebTorrent native controls (overlap with Dplayer)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -421,6 +421,7 @@ class DPlayer {
                                 const file = torrent.files.find((file) => file.name.endsWith('.mp4'));
                                 file.renderTo(this.video, {
                                     autoplay: this.options.autoplay,
+                                    controls: false
                                 });
                             });
                             this.events.on('destroy', () => {


### PR DESCRIPTION
隐藏WebTorrent原生控制条，避免与Dplayer控制条重叠。

环境：Chrome 78.0.3904.97, DPlayer.min.js cb95daa, WebTorrent 0.107.17

Before (when paused):
![2019-11-21-22-20](https://user-images.githubusercontent.com/7879628/69347652-d7f21c80-0caf-11ea-9481-92197b2843a5.PNG)

After (when paused):
![2019-11-21-22-42](https://user-images.githubusercontent.com/7879628/69347952-5484fb00-0cb0-11ea-8794-2807571d8422.PNG)
