### PR TITLE
Fix Web Fullscreen layout error when container set width or height

### DIFF
--- a/src/css/player.scss
+++ b/src/css/player.scss
@@ -160,8 +160,8 @@
         z-index: 100000;
         left: 0;
         top: 0;
-        width: 100%;
-        height: 100%;
+        width: 100% !important;
+        height: 100% !important;
     }
     &.dplayer-mobile {
         .dplayer-controller .dplayer-icons {


### PR DESCRIPTION
When set width or height on DPlayer's container, Web Fullscreen layout is bad.
It is only displayed in the upper left corner and not extend to Fullscreen.
Add !important to imporve priority for fix it.