### PR TITLE
Add flv.js config support

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -618,7 +618,10 @@ const dp = new DPlayer({
     },
     pluginOptions: {
         flv: {
-            // flv config
+            // flv.js Config
+        },
+        flvjs: {
+            // flv.js MediaDataSource
         },
     },
 });

--- a/docs/zh/guide.md
+++ b/docs/zh/guide.md
@@ -604,7 +604,10 @@ const dp = new DPlayer({
     },
     pluginOptions: {
         flv: {
-            // flv config
+            // flv.js Config
+        },
+        flvjs: {
+            // flv.js MediaDataSource
         },
     },
 });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -18,7 +18,7 @@ export default (options) => {
         video: {},
         contextmenu: [],
         mutex: true,
-        pluginOptions: { hls: {}, flvjs: {}, dash: {}, webtorrent: {} },
+        pluginOptions: { hls: {}, flv: {}, flvjs: {}, dash: {}, webtorrent: {} },
     };
     for (const defaultKey in defaultOption) {
         if (defaultOption.hasOwnProperty(defaultKey) && !options.hasOwnProperty(defaultKey)) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -368,7 +368,8 @@ class DPlayer {
                                 type: 'flv',
                                 url: video.src,
                             });
-                            const flvPlayer = window.flvjs.createPlayer(options);
+                            const config = Object.assign(this.options.pluginOptions.flv, {});
+                            const flvPlayer = window.flvjs.createPlayer(options, config);
                             this.plugins.flvjs = flvPlayer;
                             flvPlayer.attachMediaElement(video);
                             flvPlayer.load();


### PR DESCRIPTION
When my trying to config flv.js with config option lazyLoad, I found the flv.js have two types of setting types.

One is MediaDataSource, this is already exposed at commit https://github.com/MoePlayer/DPlayer/commit/f95c7dce3eee60571ad65286c45dbac397858350 , another one is Config, this is not exposed on DPlayer.

This PR exposed flv.js config option, naming it flv. If this name is not good, We can talk about it's naming.  

Naming it as flv from a typo in document. DPlayer exposed flv.js MediaDataSource name is flvjs in code, but flv in document, this PR also fix it.