### PR TITLE
Info panel update with music area that retrieve details from API

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -71,12 +71,6 @@ function initPlayers () {
             id: '9E2E3368B56CDBB4',
             api: 'https://api.prprpr.me/dplayer/',
             addition: ['https://cn-south-17-dplayer-49648867.oss.dogecdn.com/1678963.json']
-        },
-        musicRecognition: {
-            isActive: true,
-            apiUrl: '',
-            apiKey: '',
-            songSearch: 'Goose House Hikaru Nara'
         }
     });
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -71,6 +71,12 @@ function initPlayers () {
             id: '9E2E3368B56CDBB4',
             api: 'https://api.prprpr.me/dplayer/',
             addition: ['https://cn-south-17-dplayer-49648867.oss.dogecdn.com/1678963.json']
+        },
+        musicRecognition: {
+            isActive: true,
+            apiUrl: '',
+            apiKey: '',
+            songSearch: 'Goose House Hikaru Nara'
         }
     });
 

--- a/src/js/info-panel.js
+++ b/src/js/info-panel.js
@@ -45,6 +45,40 @@ class InfoPanel {
             this.template.infoDanmakuApi.innerHTML = this.player.options.danmaku.api;
             this.template.infoDanmakuAmount.innerHTML = this.player.danmaku.dan.length;
         }
+        if (this.player.options.musicRecognition.isActive) {
+            this.musicRecognitionApi();
+            this.template.infoMusicRecognitionTitle.innerHTML = localStorage.getItem('title');
+            this.template.infoMusicRecognitionArtist.innerHTML = localStorage.getItem('artist');
+            this.template.infoMusicRecognitionTitleLyrics.innerHTML = "<a href='" + localStorage.getItem('lyrics') + '\' target="_blank">' + localStorage.getItem('lyrics') + '</a>';
+        }
+    }
+
+    musicRecognitionApi() {
+        const request = require('request');
+
+        const options = {
+            method: 'GET',
+            url: 'https://genius.p.rapidapi.com/search',
+            qs: { q: this.player.options.musicRecognition.songSearch.toString() },
+            headers: {
+                'x-rapidapi-host': this.player.options.musicRecognition.apiUrl.toString(),
+                'x-rapidapi-key': this.player.options.musicRecognition.apiKey.toString(),
+            },
+        };
+
+        request(options, function(error, response, body) {
+            if (error) {
+                throw new Error(error);
+            }
+
+            const obj = JSON.parse(body);
+            localStorage.removeItem('title');
+            localStorage.setItem('title', obj.response.hits[0].result.title.toString());
+            localStorage.removeItem('artist');
+            localStorage.setItem('artist', obj.response.hits[0].result.primary_artist.name.toString());
+            localStorage.removeItem('album');
+            localStorage.setItem('lyrics', obj.response.hits[0].result.url.toString());
+        });
     }
 
     fps(value) {

--- a/src/js/info-panel.js
+++ b/src/js/info-panel.js
@@ -72,11 +72,8 @@ class InfoPanel {
             }
 
             const obj = JSON.parse(body);
-            localStorage.removeItem('title');
             localStorage.setItem('title', obj.response.hits[0].result.title.toString());
-            localStorage.removeItem('artist');
             localStorage.setItem('artist', obj.response.hits[0].result.primary_artist.name.toString());
-            localStorage.removeItem('album');
             localStorage.setItem('lyrics', obj.response.hits[0].result.url.toString());
         });
     }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -19,6 +19,7 @@ export default (options) => {
         contextmenu: [],
         mutex: true,
         pluginOptions: { hls: {}, flvjs: {}, dash: {}, webtorrent: {} },
+        musicRecognition: { isActive: false, apiUrl: '', apiKey: '', songSearch: '' },
     };
     for (const defaultKey in defaultOption) {
         if (defaultOption.hasOwnProperty(defaultKey) && !options.hasOwnProperty(defaultKey)) {

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -96,6 +96,9 @@ class Template {
         this.infoDanmakuId = this.container.querySelector('.dplayer-info-panel-item-danmaku-id .dplayer-info-panel-item-data');
         this.infoDanmakuApi = this.container.querySelector('.dplayer-info-panel-item-danmaku-api .dplayer-info-panel-item-data');
         this.infoDanmakuAmount = this.container.querySelector('.dplayer-info-panel-item-danmaku-amount .dplayer-info-panel-item-data');
+        this.infoMusicRecognitionTitle = this.container.querySelector('.dplayer-info-panel-item-musicRecognition-title .dplayer-info-panel-item-data');
+        this.infoMusicRecognitionArtist = this.container.querySelector('.dplayer-info-panel-item-musicRecognition-artist .dplayer-info-panel-item-data');
+        this.infoMusicRecognitionTitleLyrics = this.container.querySelector('.dplayer-info-panel-item-musicRecognition-lyrics .dplayer-info-panel-item-data');
     }
 }
 

--- a/src/template/player.art
+++ b/src/template/player.art
@@ -255,6 +255,7 @@
     {{ if options.musicRecognition.isActive }}
     </br>
     <div><b>Music in this video</b></div>
+    <div>Information are given from Genius</div>
     </br>
     <div class="dplayer-info-panel-item dplayer-info-panel-item-musicRecognition-title">
         <span class="dplayer-info-panel-item-title">Song</span>

--- a/src/template/player.art
+++ b/src/template/player.art
@@ -213,7 +213,6 @@
 </div>
 <div class="dplayer-info-panel dplayer-info-panel-hide">
     <div class="dplayer-info-panel-close">[x]</div>
-    <div><b>Video inf</b></div>
     </br>
     <div class="dplayer-info-panel-item dplayer-info-panel-item-version">
         <span class="dplayer-info-panel-item-title">Player version</span>

--- a/src/template/player.art
+++ b/src/template/player.art
@@ -213,6 +213,8 @@
 </div>
 <div class="dplayer-info-panel dplayer-info-panel-hide">
     <div class="dplayer-info-panel-close">[x]</div>
+    <div><b>Video inf</b></div>
+    </br>
     <div class="dplayer-info-panel-item dplayer-info-panel-item-version">
         <span class="dplayer-info-panel-item-title">Player version</span>
         <span class="dplayer-info-panel-item-data"></span>
@@ -248,6 +250,23 @@
     </div>
     <div class="dplayer-info-panel-item dplayer-info-panel-item-danmaku-amount">
         <span class="dplayer-info-panel-item-title">Danamku amount</span>
+        <span class="dplayer-info-panel-item-data"></span>
+    </div>
+    {{ /if }}
+    {{ if options.musicRecognition.isActive }}
+    </br>
+    <div><b>Music in this video</b></div>
+    </br>
+    <div class="dplayer-info-panel-item dplayer-info-panel-item-musicRecognition-title">
+        <span class="dplayer-info-panel-item-title">Song</span>
+        <span class="dplayer-info-panel-item-data"></span>
+    </div>
+    <div class="dplayer-info-panel-item dplayer-info-panel-item-musicRecognition-artist">
+        <span class="dplayer-info-panel-item-title">Artist</span>
+        <span class="dplayer-info-panel-item-data"></span>
+    </div>
+    <div class="dplayer-info-panel-item dplayer-info-panel-item-musicRecognition-lyrics">
+        <span class="dplayer-info-panel-item-title">Lyrics</span>
         <span class="dplayer-info-panel-item-data"></span>
     </div>
     {{ /if }}


### PR DESCRIPTION
I update the info panel of the DPlayer with music area (Music in this video) that retrieve information about the music in the video from Genius from rapidapi.com: https://rapidapi.com/brianiswu/api/genius

The default settings do not use the API.
![image](https://user-images.githubusercontent.com/36899728/78650560-c2306d00-78c7-11ea-8b1c-1032026a3b23.png)

If we want to use the API from rapidapi.com then we add in the player instance:
![image](https://user-images.githubusercontent.com/36899728/78650728-f99f1980-78c7-11ea-817f-c5e51ad10106.png)

- isActive -> in that part we set it to true in order to activate the API part
- apiUrl -> in that part we add the x-rapidapi-host
- apiKey -> in that part we add the x-rapidapi-key
- songSearch -> in that part we add the music title that we want to get information from Genius

The result will be:
![image](https://user-images.githubusercontent.com/36899728/78651091-83e77d80-78c8-11ea-9775-88d27266a580.png)

