### PR TITLE
Fix AirPlay Button Display on Firefox Windows Version

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -30,9 +30,7 @@ class Controller {
         this.initScreenshotButton();
         this.initSubtitleButton();
         this.initHighlights();
-        if (utils.isSafari) {
-            this.initAirplayButton();
-        }
+        this.initAirplayButton();
         if (!utils.isMobile) {
             this.initVolumeButton();
         }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,7 +1,5 @@
 const isMobile = /mobile/i.test(window.navigator.userAgent);
 
-const isSafari = /Safari/i.test(window.navigator.userAgent);
-
 const utils = {
     /**
      * Parse second to time string
@@ -90,8 +88,6 @@ const utils = {
     },
 
     isMobile: isMobile,
-
-    isSafari: isSafari,
 
     isFirefox: /firefox/i.test(window.navigator.userAgent),
 


### PR DESCRIPTION
Related Issue: https://github.com/MoePlayer/DPlayer/issues/901

Because Windows Version of Firefox's user agent doesn't contains 'Safari', so the initAirplayButton function not running and don't set the AirPlay Button hidden.

This PR removes the condition that the initAirplayButton function only runs on browsers where the user agent contains "Safari", judges whether AirPlay is supported based on browser capabilities and fix this bug.