### PR TITLE
Update live option control in player.js

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -50,6 +50,9 @@ class DPlayer {
         if (this.options.live) {
             this.container.classList.add('dplayer-live');
         }
+        else {
+            this.container.classList.remove("dplayer-live");
+        }
         if (utils.isMobile) {
             this.container.classList.add('dplayer-mobile');
         }


### PR DESCRIPTION
There is no problem switching from a full video that's not live streaming to a live video but if the reverse, the full video would not display the video time and cannot drag the progress bar. I suggest adding the API function of live broadcast control. For the moment, I removed the `dplayer-live` class name to solve the problem I encountered.