### PR TITLE
fix:destroy之后 video 会继续触发事件

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -613,6 +613,9 @@ class DPlayer {
         this.video.src = '';
         this.container.innerHTML = '';
         this.events.trigger('destroy');
+        Object.keys(this.events.events).forEach((key) => {
+            this.off(key);
+        });
     }
 
     static get version() {


### PR DESCRIPTION
`destroy` 之后 `video` 会继续触发事件。
例如，如果监听了 `error` 事件，因为代码中 `this.video.src = '';` 将视频地址置空，会触发 `MediaError {code: 4, message: "MEDIA_ELEMENT_ERROR: Empty src attribute"}`。
所以组件销毁之后，组件应该不再继续监听事件。