### PR TITLE
修复了切换清晰度时 hls 等实例不被销毁导致内存泄漏的问题

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -412,15 +412,56 @@ const dp = new DPlayer({
 });
 ```
 
+When using `customType` ([Work with other MSE library](#work-with-other-mse-library)), you should listen for the `destroy` and `quality_end` events to destroy the MSE library instance in a timely manner to avoid memory leaks.
+
+```js
+const dp = new DPlayer({
+    container: document.getElementById('dplayer'),
+    video: {
+        quality: [
+            {
+                name: 'HD',
+                url: 'demo_hd.m3u8',
+                type: 'Hls',
+            },
+            {
+                name: 'SD',
+                url: 'demo_sd.m3u8',
+                type: 'Hls',
+            },
+        ],
+        defaultQuality: 0,
+        customType: {
+            Hls: (video, player) => {
+                const hls = new window.Hls();
+                hls.loadSource(video.src);
+                hls.attachMedia(video);
+
+                hls.sessionId = crypto.randomUUID();
+                player.sessionId = hls.sessionId;
+                player.events.on('destroy', () => {
+                    hls.destroy();
+                });
+                player.events.on('quality_end', () => {
+                    if (hls.sessionId !== player.sessionId) {
+                        hls.destroy();
+                    }
+                });
+            },
+        },
+    },
+});
+```
+
 ## Danmaku
 
 ### Danmaku API
 
 `danmaku.api`
 
-**Ready-made API**
+<!-- **Ready-made API**
 
-url: https://api.prprpr.me/dplayer/
+url: https://api.prprpr.me/dplayer/ -->
 
 Daily backup data: [DPlayer-data](https://github.com/DIYgod/DPlayer-data)
 

--- a/docs/zh/guide.md
+++ b/docs/zh/guide.md
@@ -396,15 +396,56 @@ const dp = new DPlayer({
 });
 ```
 
+在使用 `customType` [配合其他 MSE 库使用](#配合其他-mse-库使用)时，需要监听 `destroy` 和 `quality_end` 事件及时销毁 MSE 库实例，避免内存泄漏
+
+```js
+const dp = new DPlayer({
+    container: document.getElementById('dplayer'),
+    video: {
+        quality: [
+            {
+                name: 'HD',
+                url: 'demo_hd.m3u8',
+                type: 'Hls',
+            },
+            {
+                name: 'SD',
+                url: 'demo_sd.m3u8',
+                type: 'Hls',
+            },
+        ],
+        defaultQuality: 0,
+        customType: {
+            Hls: (video, player) => {
+                const hls = new window.Hls();
+                hls.loadSource(video.src);
+                hls.attachMedia(video);
+
+                hls.sessionId = crypto.randomUUID();
+                player.sessionId = hls.sessionId;
+                player.events.on('destroy', () => {
+                    hls.destroy();
+                });
+                player.events.on('quality_end', () => {
+                    if (hls.sessionId !== player.sessionId) {
+                        hls.destroy();
+                    }
+                });
+            },
+        },
+    },
+});
+```
+
 ## 弹幕
 
 ### 弹幕接口
 
 `danmaku.api`
 
-**现成的接口**
+<!-- **现成的接口**
 
-链接: https://api.prprpr.me/dplayer/
+链接: https://api.prprpr.me/dplayer/ -->
 
 每日备份: [DPlayer-data](https://github.com/DIYgod/DPlayer-data)
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -382,6 +382,7 @@ class DPlayer {
                 this.type = 'normal';
             }
 
+            const src = this.quality.url; // 真实的视频 url, 用于切换清晰度时销毁实例
             switch (this.type) {
                 // https://github.com/video-dev/hls.js
                 case 'hls':
@@ -395,6 +396,12 @@ class DPlayer {
                             this.events.on('destroy', () => {
                                 hls.destroy();
                                 delete this.plugins.hls;
+                            });
+                            // 切换清晰度时销毁实例
+                            this.events.on('quality_end', () => {
+                                if (src !== this.quality.url) {
+                                    hls.destroy();
+                                }
                             });
                         } else {
                             this.notice('Error: Hls is not supported.');
@@ -424,6 +431,14 @@ class DPlayer {
                                 flvPlayer.destroy();
                                 delete this.plugins.flvjs;
                             });
+                            // 切换清晰度时销毁实例
+                            this.events.on('quality_end', () => {
+                                if (src !== this.quality.url) {
+                                    flvPlayer.unload();
+                                    flvPlayer.detachMediaElement();
+                                    flvPlayer.destroy();
+                                }
+                            });
                         } else {
                             this.notice('Error: flvjs is not supported.');
                         }
@@ -443,6 +458,12 @@ class DPlayer {
                         this.events.on('destroy', () => {
                             window.dashjs.MediaPlayer().reset();
                             delete this.plugins.dash;
+                        });
+                        // 切换清晰度时销毁实例
+                        this.events.on('quality_end', () => {
+                            if (src !== this.quality.url) {
+                                window.dashjs.MediaPlayer().reset();
+                            }
                         });
                     } else {
                         this.notice("Error: Can't find dashjs.");
@@ -472,6 +493,13 @@ class DPlayer {
                                 client.remove(torrentId);
                                 client.destroy();
                                 delete this.plugins.webtorrent;
+                            });
+                            // 切换清晰度时销毁实例
+                            this.events.on('quality_end', () => {
+                                if (src !== this.quality.url) {
+                                    client.remove(torrentId);
+                                    client.destroy();
+                                }
                             });
                         } else {
                             this.notice('Error: Webtorrent is not supported.');


### PR DESCRIPTION
修复了切换清晰度时 hls 等实例不被销毁导致内存泄漏的问题。

**复现方法：**
```javascript
new DPlayer({
    container: document.getElementById('dplayer'),
    video: {
        quality: [
            {
                name: '1080P',
                url: 'https://plwb21.live.weibo.com/alicdn/5267743525044711.m3u8',
                type: 'hls'
            },
            {
                name: '720P',
                url: 'https://plwb21.live.weibo.com/alicdn/5267743525044711_wb720avc.m3u8',
                type: 'hls'
            },
            {
                name: '540P',
                url: 'https://plwb21.live.weibo.com/alicdn/5267743525044711_wb540avc.m3u8',
                type: 'hls'
            },
            {
                name: '480P',
                url: 'https://plwb21.live.weibo.com/alicdn/5267743525044711_wb480avc.m3u8',
                type: 'hls'
            }
        ],
        defaultQuality: 0,
    },
    live: true,
})
```
由 1080P 切换至 720P，观察网络请求，发现除请求 720P 的`/5267743525044711_wb720avc.m3u8`外，仍在请求 1080P 的`/5267743525044711.m3u8`。

**出现原因：**
`initMSE(video, type)`中，在 hls 等实例未被销毁的前提下，又一次创建了这些实例。

**修复：**
通过监听`quality_end`事件，判断当前实例对应的`quality.url`是否是当前的`quality.url`。若否，销毁当前实例。

**不足：**
`customType` 中的配置无法做修改，仍会导致内存泄漏。或许可以通过文档要求用户监听`quality_end`事件销毁实例。